### PR TITLE
Better support for Plover (Stenography)

### DIFF
--- a/mitype/app.py
+++ b/mitype/app.py
@@ -197,13 +197,16 @@ class App:
         elif mitype.keycheck.is_backspace(key):
             self.erase_key()
 
-        # Check for space
-        elif key == " ":
-            self.check_word()
+        # Ignore spaces at the start of the word (Plover support)
+        elif not (key == " " and len(self.current_word) == 0):
+            
+            # Check for space
+            if key == " ":
+                self.check_word()
 
-        # Check for any other typable characters
-        elif mitype.keycheck.is_valid_initial_key(key):
-            self.appendkey(key)
+            # Check for any other typable characters
+            elif mitype.keycheck.is_valid_initial_key(key):
+                self.appendkey(key)
 
         # Update state of window
         self.update_state(win)

--- a/mitype/app.py
+++ b/mitype/app.py
@@ -198,15 +198,12 @@ class App:
             self.erase_key()
 
         # Ignore spaces at the start of the word (Plover support)
-        elif not (key == " " and len(self.current_word) == 0):
-            
-            # Check for space
-            if key == " ":
+        elif key==" ":
+            if self.current_word!="":
                 self.check_word()
 
-            # Check for any other typable characters
-            elif mitype.keycheck.is_valid_initial_key(key):
-                self.appendkey(key)
+        elif mitype.keycheck.is_valid_initial_key(key):
+            self.appendkey(key)
 
         # Update state of window
         self.update_state(win)


### PR DESCRIPTION
This PR adds better support to Plover, ignoring spaces at the start of every word, since Plover always adds a space before each word.

Tested with python version - 3.8.5

On operating system - Arch Linux x86_64, kernel 5.8.12-arch1-1