### PR TITLE
Fix visual glitch when using backspace to clear text on multiple rows

### DIFF
--- a/mitype/app.py
+++ b/mitype/app.py
@@ -282,7 +282,9 @@ class App:
             win (any): Curses window.
         """
         win.addstr(self.line_count, 0, " " * self.window_width)
+        win.addstr(self.line_count + 1, 0, " " * self.window_width)
         win.addstr(self.line_count + 2, 0, " " * self.window_width)
+        win.addstr(self.line_count + 3, 0, " " * self.window_width)
         win.addstr(self.line_count + 4, 0, " " * self.window_width)
         win.addstr(self.line_count, 0, self.current_word)
 


### PR DESCRIPTION
This PR fixes #59 

Tested with python version - 2.7.16, 3.8.5

On operating system - macOS Catalina, Version 10.15.7