### PR TITLE
History feature broken in python 2

### DIFF
--- a/mitype/history.py
+++ b/mitype/history.py
@@ -69,12 +69,12 @@ def save_history(text_id, current_speed_wpm, accuracy):
 
     if not os.path.isfile(history_path):
         row = ["ID", "WPM", "DATE", "TIME", "ACCURACY"]
-        history = open(history_path, "a", newline="")
+        history = open(history_path, "ab")
         csv_history = csv.writer(history)
         csv_history.writerow(row)
         history.close()
 
-    history = open(history_path, "a", newline="")
+    history = open(history_path, "ab")
     csv_history = csv.writer(history)
 
     current_time = time.strftime("%H:%M:%S", time.localtime())

--- a/mitype/history.py
+++ b/mitype/history.py
@@ -2,6 +2,7 @@
 
 import csv
 import os
+import sys
 import time
 from datetime import date
 
@@ -67,15 +68,18 @@ def save_history(text_id, current_speed_wpm, accuracy):
     """
     history_path = history_file_absolute_path()
 
-    if not os.path.isfile(history_path):
-        row = ["ID", "WPM", "DATE", "TIME", "ACCURACY"]
+    file_exists = os.path.isfile(history_path)
+
+    if sys.version_info[0] < 3:
         history = open(history_path, "ab")
         csv_history = csv.writer(history)
-        csv_history.writerow(row)
-        history.close()
+    else:
+        history = open(history_path, "a", newline="")
+        csv_history = csv.writer(history)
 
-    history = open(history_path, "ab")
-    csv_history = csv.writer(history)
+    if not file_exists:
+        row = ["ID", "WPM", "DATE", "TIME", "ACCURACY"]
+        csv_history.writerow(row)
 
     current_time = time.strftime("%H:%M:%S", time.localtime())
 


### PR DESCRIPTION
CSV writer added an extra newline in windows. This can be avoided by adding the `newline=""` parameter while opening file. But this parameter is invalid in python2. To overcome this, the file must be opened as a binary file in python2.

[Reference](https://stackoverflow.com/questions/3191528/csv-in-python-adding-an-extra-carriage-return-on-windows#:~:text=You%20can%20introduce%20the%20lineterminator,in%20the%20csv%20writer%20command.&text=Note%20that%20if%20you%20use,to%20remove%20the%20extra%20newline.)