### PR TITLE
Change keycheck.py and timer.py for correct format

### DIFF
--- a/mitype/keycheck.py
+++ b/mitype/keycheck.py
@@ -16,7 +16,8 @@ def is_escape(key):
             KEY_UP or ^G.
 
     Returns:
-        bool: Returns `True` if pressed key is ESC key.
+        bool:
+            Returns `True` if pressed key is ESC key.
             Returns `False` otherwise.
     """
     if isinstance(key, str) and len(key) == 1:
@@ -33,7 +34,8 @@ def is_ctrl_c(key):
         key (str): Character to check.
 
     Returns:
-        bool: Returns `True` if Ctrl+c is pressed.
+        bool: 
+            Returns `True` if Ctrl+c is pressed.
             Returns `False` otherwise.
     """
     return key == "\x03"
@@ -47,7 +49,8 @@ def is_ctrl_t(key):
     Args:
         key (str): Character to check.
     Returns:
-        bool: Return `True` if Ctrl+t is pressed.
+        bool: 
+            Return `True` if Ctrl+t is pressed.
             Return `False` otherwise.
     """
     return key == "\x14"
@@ -62,7 +65,8 @@ def is_ctrl_backspace(key):
         key (str): Character to check.
 
     Returns:
-        bool: Returns `True` if Ctrl+backspace is pressed.
+        bool: 
+            Returns `True` if Ctrl+backspace is pressed.
             Returns `False` otherwise.
     """
     return key == "\x17"
@@ -75,7 +79,8 @@ def is_backspace(key):
         key (str): Character to check.
 
     Returns:
-        bool: Returns `True` if pressed key is BACKSPACE key.
+        bool: 
+            Returns `True` if pressed key is BACKSPACE key.
             Returns `False` otherwise.
     """
     if key in ("KEY_BACKSPACE", "\b", "\x7f"):
@@ -142,7 +147,8 @@ def is_ignored_key(key):
         key (str): Character to check.
 
     Returns:
-        bool: Returns `True` if pressed key must be ignored or `False`
+        bool: 
+            Returns `True` if pressed key must be ignored or `False`
             otherwise.
     """
     if sys.version_info[0] < 3:

--- a/mitype/keycheck.py
+++ b/mitype/keycheck.py
@@ -16,9 +16,8 @@ def is_escape(key):
             KEY_UP or ^G.
 
     Returns:
-        bool:
-            Returns `True` if pressed key is ESC key.
-            Returns `False` otherwise.
+        bool: Returns `True` if pressed key is ESC key.
+        Returns `False` otherwise.
     """
     if isinstance(key, str) and len(key) == 1:
         return ord(key) == curses.ascii.ESC
@@ -34,9 +33,8 @@ def is_ctrl_c(key):
         key (str): Character to check.
 
     Returns:
-        bool: 
-            Returns `True` if Ctrl+c is pressed.
-            Returns `False` otherwise.
+        bool: Returns `True` if Ctrl+c is pressed.
+        Returns `False` otherwise.
     """
     return key == "\x03"
 
@@ -49,9 +47,8 @@ def is_ctrl_t(key):
     Args:
         key (str): Character to check.
     Returns:
-        bool: 
-            Return `True` if Ctrl+t is pressed.
-            Return `False` otherwise.
+        bool: Return `True` if Ctrl+t is pressed.
+        Return `False` otherwise.
     """
     return key == "\x14"
 
@@ -65,9 +62,8 @@ def is_ctrl_backspace(key):
         key (str): Character to check.
 
     Returns:
-        bool: 
-            Returns `True` if Ctrl+backspace is pressed.
-            Returns `False` otherwise.
+        bool: Returns `True` if Ctrl+backspace is pressed.
+        Returns `False` otherwise.
     """
     return key == "\x17"
 
@@ -79,9 +75,8 @@ def is_backspace(key):
         key (str): Character to check.
 
     Returns:
-        bool: 
-            Returns `True` if pressed key is BACKSPACE key.
-            Returns `False` otherwise.
+        bool: Returns `True` if pressed key is BACKSPACE key.
+        Returns `False` otherwise.
     """
     if key in ("KEY_BACKSPACE", "\b", "\x7f"):
         return True
@@ -147,9 +142,8 @@ def is_ignored_key(key):
         key (str): Character to check.
 
     Returns:
-        bool: 
-            Returns `True` if pressed key must be ignored or `False`
-            otherwise.
+        bool: Returns `True` if pressed key must be ignored or `False`
+        otherwise.
     """
     if sys.version_info[0] < 3:
         return key.startswith("KEY") or (len(key) > 1 and key.startswith("k"))

--- a/mitype/timer.py
+++ b/mitype/timer.py
@@ -13,7 +13,8 @@ def get_elapsed_seconds_since_first_keypress(start_time):
             the sample text.
 
     Returns:
-        float: Time elapsed since start of typing session till calling
+        float: 
+            Time elapsed since start of typing session till calling
             this function.
     """
     return time.time() - start_time

--- a/mitype/timer.py
+++ b/mitype/timer.py
@@ -13,8 +13,7 @@ def get_elapsed_seconds_since_first_keypress(start_time):
             the sample text.
 
     Returns:
-        float: 
-            Time elapsed since start of typing session till calling
-            this function.
+        float: Time elapsed since start of typing session till calling
+        this function.
     """
     return time.time() - start_time


### PR DESCRIPTION

Correct formatting on docstring with multi-line return.
Change in keycheck.py and timer.py file which is present in mitype directory. These files were causing the issue in the return statement formating.

This PR fixes #84 

