### PR TITLE
Space key overriding maximum length of mistyped characters

### DIFF
--- a/mitype/app.py
+++ b/mitype/app.py
@@ -264,7 +264,7 @@ class App:
             self.erase_word()
 
         # Ignore spaces at the start of the word (Plover support)
-        elif key == " ":
+        elif key == " " and len(self.current_word) < self.current_word_limit:
             if self.current_word != "":
                 self.check_word()
 


### PR DESCRIPTION
This PR fixes #93
Tested with python version -  3.9.6
On operating system - Arch Linux