### PR TITLE
fix outOfIndex error for mistyped keys

### DIFF
--- a/mitype/app.py
+++ b/mitype/app.py
@@ -249,7 +249,7 @@ class App:
 
         index = first_index_at_which_strings_differ(self.current_string, self.text)
         # Check if difference was found
-        if index < len(self.current_string):
+        if index < len(self.current_string) and len(self.current_string) <= len(self.text):
             self.mistyped_keys.append(len(self.current_string) - 1)
 
         win.addstr(


### PR DESCRIPTION
This PR fixes #105 

Tested with python version - 3.9.7

On operating system - Windows 10
