### PR TITLE
Save all test records in history

### DIFF
--- a/mitype/app.py
+++ b/mitype/app.py
@@ -553,6 +553,7 @@ class App:
         self.total_chars_typed = 0
         self.accuracy = 0
         self.time_taken = 0
+        self.test_complete = False
         curses.curs_set(1)
 
     def switch_text(self, win, value):


### PR DESCRIPTION
This PR fixes #118 

The `test_complete` was only set to False when the App started. It needs to be set to `False`  when the app resets to track history when we retry and change the text by pressing `Tab`

Tested with python version - 3.8.5 

On operating system - MacOS BigSur 11.5.2

If you decide to merge, please attach the appropriate Hacktoberfest tags.
