### PR TITLE
Add feature: Make mitype easier to debug

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,1 @@
+remote-pdb

--- a/testing/debug-attach
+++ b/testing/debug-attach
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec rlwrap telnet 127.0.0.1 4444

--- a/testing/debug-mitype
+++ b/testing/debug-mitype
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+export \
+    PYTHONBREAKPOINT=remote_pdb.set_trace \
+    REMOTE_PDB_HOST=127.0.0.1 \
+    REMOTE_PDB_PORT=4444 \
+    REMOTE_PDB_QUIET=1
+exec mitype "$@"


### PR DESCRIPTION
Fixes #145

Tested with python version CPython 3.10 

On operating system Linux
