### PR TITLE
Word wrap text when switching between texts

### DIFF
--- a/mitype/app.py
+++ b/mitype/app.py
@@ -581,6 +581,8 @@ class App:
         self.text = " ".join(self.tokens)
         self.text_backup = self.text
 
+        self.text = word_wrap(self.text, self.window_width)
+
         self.reset_test()
         self.setup_print(win)
         self.update_state(win)


### PR DESCRIPTION
This PR fixes #157 

Tested with python version - 3.11.5

On operating system - ManjaroLinux
