### PR TITLE
Fix apostrophes not typing on Windows

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -19,7 +19,7 @@ python -m mitype [OPTION]... [FILE]...
 You'll need [windows_curses](https://pypi.org/project/windows-curses/) installed for running mitype on windows.
 You can install it by running the following command.
 ```
-pip install windows_curses
+pip install windows_curses==2.3.0
 ```
 
 ## Installing from Source

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ classifiers =
 [options]
 packages = mitype
 install_requires =
-    windows-curses; platform_system=='Windows'
+    windows-curses==2.3.0; platform_system=='Windows'
 include_package_data = True
 zip_safe = False
 


### PR DESCRIPTION
Windows-curses bug introduced after v2.3.0 not allowing to type apostrophe character.
zephyrproject-rtos/windows-curses#41

This PR fixes #155

Tested with python version - 3.9

On operating system - Windows and Linux
