### PR TITLE
Fix apostrophes not typing on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/mitype/app.py
+++ b/mitype/app.py
@@ -18,6 +18,7 @@ from mitype.calculations import (
 from mitype.commandline import load_from_database, resolve_commandline_arguments
 from mitype.history import save_history
 from mitype.keycheck import (
+    get_key_mapping,
     is_backspace,
     is_ctrl_backspace,
     is_ctrl_c,
@@ -427,6 +428,7 @@ class App:
                 self.check_word()
 
         elif is_valid_initial_key(key):
+            key = get_key_mapping(key)
             self.appendkey(key)
             self.total_chars_typed += 1
 

--- a/mitype/keycheck.py
+++ b/mitype/keycheck.py
@@ -132,6 +132,24 @@ def is_resize(key):
     return key == "KEY_RESIZE"
 
 
+def get_key_mapping(key):
+    """Map key to its corresponding character.
+
+    Addresses a bug in windows-curses where the apostrophe key is
+    incorrectly returned as 530 -
+    https://github.com/zephyrproject-rtos/windows-curses/issues/41
+
+    Args:
+        key (Union[int, str]): Character to check.
+
+    Returns:
+        Union[int, str]: Returns character if mapping is present or original key otherwise.
+    """
+    if key == 530:
+        return "'"
+    return key
+
+
 def is_ignored_key(key):
     """Detect if key press should be ignored.
 
@@ -144,7 +162,7 @@ def is_ignored_key(key):
         bool: Returns `True` if pressed key must be ignored or `False`
         otherwise.
     """
-    return isinstance(key, int)
+    return isinstance(get_key_mapping(key), int)
 
 
 def is_valid_initial_key(key):

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,11 +20,11 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3 :: Only
 
 [options]

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ classifiers =
 [options]
 packages = mitype
 install_requires =
-    windows-curses==2.3.0; platform_system=='Windows'
+    windows-curses; platform_system=='Windows'
 include_package_data = True
 zip_safe = False
 


### PR DESCRIPTION
Apostrophes are returned as key code 530 in windows_curses==2.3.3 which is the latest version at the time of this PR. Another issue still stands with the keys ']' and '}' as they are both wrongly mapping to '\x00'.

This PR fixes #155.

Tested with python version -
- 3.9.0
- 3.11.9
- 3.12.2


On operating system -
- Windows 10
- Linux