### PR TITLE
Fix word limiter not resetting on text switch

### DIFF
--- a/mitype/app.py
+++ b/mitype/app.py
@@ -585,6 +585,10 @@ class App:
 
         self.text = word_wrap(self.text, self.window_width)
 
+        # Reset current word length
+        # limit is set to the length of largest word in string + 5 for buffer
+        self.current_word_limit = len(max(self.tokens, key=len)) + 5
+
         self.reset_test()
         self.setup_print(win)
         self.update_state(win)

--- a/mitype/app.py
+++ b/mitype/app.py
@@ -585,8 +585,6 @@ class App:
 
         self.text = word_wrap(self.text, self.window_width)
 
-        # Reset current word length
-        # limit is set to the length of largest word in string + 5 for buffer
         self.current_word_limit = len(max(self.tokens, key=len)) + 5
 
         self.reset_test()


### PR DESCRIPTION
This PR fixes #174 

Tested with python version - 3.12.10

On operating system - Windows
